### PR TITLE
修改Dockerfile配置Nginx設定檔

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM nginx
 COPY dist/ /opt/crater-account-frontend/
-VOLUME ../conf /etc/nginx/conf.d
+COPY nginx.conf /etc/nginx/conf.d


### PR DESCRIPTION
將Nginx設定檔的資料夾掛載方式改為直接拷貝。這樣可以避免因目錄權限問題而導致的Nginx配置失敗。確保設定檔案在容器內的正確位置。